### PR TITLE
Fix duplicate enum value.

### DIFF
--- a/defs/asana_oas.yaml
+++ b/defs/asana_oas.yaml
@@ -3424,8 +3424,6 @@ components:
                 - people_waving_flags
                 - splashing_narwhal
                 - trophy
-                - splashing_narwhal
-                - trophy
                 - yeti_riding_unicorn
                 - celebrating_people
                 - determined_climbers


### PR DESCRIPTION
There is a duplicate enumeration value for the `sticker_name` parameter.
As a result, the auto-generated client code for C# fails. 