### PR TITLE
Renames ui-hooks, updating readme, updating build commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,4 +99,4 @@ full_openapi_sync: library_prs docs_gen app_components serve
 
 app_components: app_components_docs_gen
 
-.DEFAULT_GOAL := latest
+.DEFAULT_GOAL := full_openapi_sync

--- a/Makefile
+++ b/Makefile
@@ -34,12 +34,12 @@ api_explorer_gen:
 code_gen: java_gen node_gen php_gen ruby_gen python_gen
 
 app_components_docs_gen:
-	node ../widdershins/widdershins.js -e pui_widdershins_config.json --summary defs/ui_hooks_oas.yaml -o source/includes/ui-hooks-reference/_index.html.md
+	node ../widdershins/widdershins.js -e pui_widdershins_config.json --summary defs/app_components_oas.yaml -o source/includes/ui-hooks-reference/_index.html.md
 
 # Only bring over spec from codez
 # Internal Asanas: See https://app.asana.com/0/0/1200652548580470/f before running
-build_spec: 
-	python $$OPENAPI_DIR/build.py && cp $$OPENAPI_DIR/dist/public_asana_oas.yaml ./defs/asana_oas.yaml
+build_spec:
+	python $$OPENAPI_DIR/build.py && cp $$OPENAPI_DIR/dist/public_asana_oas.yaml ./defs/asana_oas.yaml && $$OPENAPI_DIR/app_components_oas.yaml ./defs/app_components_oas.yaml
 
 docs_gen: build_spec docs_gen_all
 
@@ -102,7 +102,7 @@ local: code_gen docs_gen serve
 latest: update docs_gen serve
 
 # Do everything to sync the openapi spec
-full_openapi_sync: library_prs docs_gen app_components serve
+full_openapi_sync: library_prs api_explorer_pr docs_gen app_components serve
 
 app_components: app_components_docs_gen
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ bundle install # Install requirements
 For the rest of this README assume any commands that we list will be run from the root of this repository.
 
 ### How it works
-The public OpenAPI spec is located at /public/public_asana_oas.json
+The public OpenAPI spec is located at /defs/asana_oas.yaml
 
 To generate markdown from the spec, we use a forked [widdershins](https://github.com/rossgrambo/widdershins)
 
@@ -74,12 +74,14 @@ We assume these repos are siblings in your folder
 - widdershins
 - developer-docs
 
-Open a shell within developer-docs and run (we use some relative path in this command):
+Open a shell within developer-docs and ru:
 ```shell
-node ../widdershins/widdershins.js --search true --language_tabs 'shell: curl' --omitHeader true --includes markdown/* --summary defs/asana_oas.yaml --user_templates ./source/templates -o source/includes/api-reference/_index.html.md
+make
 ```
 
-Then to generate the html from the markdown, we use [slate](https://github.com/lord/slate)
+To see what this command does, read the Makefile in this repo.
+
+Then to generate the html from the markdown, we use [slate](https://github.com/lord/slate). This happens automatically when the middleman starts the server.
 ```shell
 # either run this to run locally
 bundle exec middleman server
@@ -94,7 +96,7 @@ vagrant up
 If the content you're changing is static (not generated from the OpenAPI spec), you'll edit the md in source/includes/markdown.
 
 If the content you're changing is in the OpenAPI spec, you should make the changes within codez. However, if you want to quickly test something, you can make the changes in def/asana_oas.yaml. Just remember to put the changes in codez if you want them to not be overridden.
-Then, you should run the `widdershins` command above.
+Then, you should run the `make` command above.
 I prefer to run `git diff` after doing so to see the generated changes.
 Run `bundle exec middleman server` if it's not already running, and go to the url it provides to check out the changes you made.
 

--- a/defs/app_components_oas.yaml
+++ b/defs/app_components_oas.yaml
@@ -5,7 +5,7 @@ info:
     This is the interface for handling requests for
     [App Components](https://developers.asana.com/docs/app-components-overview). This reference
     is generated from an [OpenAPI spec]
-    (https://raw.githubusercontent.com/Asana/developer-docs/master/defs/ui_hooks_oas.yaml).
+    (https://raw.githubusercontent.com/Asana/developer-docs/master/defs/app_components_oas.yaml).
   title: App Components
   termsOfService: https://asana.com/terms
   contact:

--- a/source/includes/ui-hooks-reference/_index.html.md
+++ b/source/includes/ui-hooks-reference/_index.html.md
@@ -9,7 +9,7 @@
 > Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
 
 <span class="description">
-This is the interface for handling requests for [App Components](https://developers.asana.com/docs/app-components-overview). This reference is generated from an [OpenAPI spec] (https://raw.githubusercontent.com/Asana/developer-docs/master/defs/ui_hooks_oas.yaml).
+This is the interface for handling requests for [App Components](https://developers.asana.com/docs/app-components-overview). This reference is generated from an [OpenAPI spec] (https://raw.githubusercontent.com/Asana/developer-docs/master/defs/app_components_oas.yaml).
 </span>
 
 Base URLs:


### PR DESCRIPTION
Build commands now include api_explorer as a part of full_openapi_sync. 

If this causes any problems for you feel free to remove it.