### PR TITLE
Clarify origin values in authentication section

### DIFF
--- a/source/includes/markdown/_13-platform-ui.html.md
+++ b/source/includes/markdown/_13-platform-ui.html.md
@@ -375,7 +375,7 @@ authenticationUrl request after the Oauth flow is completed:
   <body>
     Success!
     <script>
-      window.opener.postMessage("success", "ORIGIN");
+      window.opener.postMessage("success", "https://app.asana.com");
       window.close();
     </script>
   </body>
@@ -397,8 +397,9 @@ with "success"  using [window.postMessage](https://developer.mozilla.org/en-US/d
 for this `postMessage` call should be the opener, accessible via
 [window.opener](https://developer.mozilla.org/en-US/docs/Web/API/Window/opener).
 
-Note that for security purposes, the _origin_ included in the event needs to match the `serverUrl` registered to the app. That is,
-the origin serving the `authenticationUrl` response must match the app's configured `serverUrl`.
+Note that for security purposes, the _origin_ of the event (which is added to the event by the browser) needs to match the `serverUrl`
+registered to the app. That is, the origin serving the `authenticationUrl` response must match the app's configured `serverUrl`.
+This is different from the `targetOrigin` of the `window.opener.postMessage` call, which must be exactly `"https://app.asana.com"`.
 
 ### Additional notes
 


### PR DESCRIPTION
Updates the App Components authentication guide to clarify that the event origin is set by the browser, and that the `targetOrigin` of the window.opener.postMessage call must match the Asana URL.

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->