### PR TITLE
Provide instructions on triggering install flow

### DIFF
--- a/source/includes/markdown/_13-platform-ui.html.md
+++ b/source/includes/markdown/_13-platform-ui.html.md
@@ -284,7 +284,9 @@ Before you begin, you'll need a developer sandbox in order to use App Components
 1. Clone [this repository](https://github.com/Asana/app-components-example-app) containing an example Express server.
 2. Follow the instructions in the [README](https://github.com/Asana/app-components-example-app/blob/main/README.md) to run the server. This server needs to remain on as you use the example app.
 3. Open the developer sandbox in your browser.
-4. In an existing project, go to **Customize** > **Apps** > **{Example}** to install the App Components example app.
+4. In an existing project, go to **Customize** > **Apps** > **{Example}** to install the App Components example app. 
+    - **Important**: to see the installation experience again after insalling the app for the first time, navigate to 
+      `https://app.asana.com/-/install_platform_ui_app?app_id=<app_client_id>`.
 <br>
 <br>
 <img src="../images/example-app-gallery-tile.png" />
@@ -332,6 +334,7 @@ When testing your application, you should:
 * Try to "break" your forms (e.g., test watched fields, limit invalid submissions, test typeahead fetches, etc.)
 * Test and proof-read any custom error messages
 * Test the auth flow from both the web browser and [desktop app](https://asana.com/download)
+  * You can enter the installation flow manually by navigating to `https://app.asana.com/-/install_platform_ui_app?app_id=<app_client_id>`
 * Test app actions with a variety of trigger combinations
 
 <hr>

--- a/source/includes/markdown/_13-platform-ui.html.md
+++ b/source/includes/markdown/_13-platform-ui.html.md
@@ -285,7 +285,7 @@ Before you begin, you'll need a developer sandbox in order to use App Components
 2. Follow the instructions in the [README](https://github.com/Asana/app-components-example-app/blob/main/README.md) to run the server. This server needs to remain on as you use the example app.
 3. Open the developer sandbox in your browser.
 4. In an existing project, go to **Customize** > **Apps** > **{Example}** to install the App Components example app. 
-    - **Important**: to see the installation experience again after insalling the app for the first time, navigate to 
+    - **Important**: The installation flow this takes you through is only shown once per user. To see it a second time, navigate to 
       `https://app.asana.com/-/install_platform_ui_app?app_id=<app_client_id>`.
 <br>
 <br>


### PR DESCRIPTION
Attempts to address a common developer pitfall when testing apps by providing instructions on how to manually trigger the installation flow after an app has been installed in a domain for the first time.

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->