### PR TITLE
Update docs to reflect removal of serverUrl

### DIFF
--- a/source/includes/markdown/_13-platform-ui.html.md
+++ b/source/includes/markdown/_13-platform-ui.html.md
@@ -400,9 +400,10 @@ with "success"  using [window.postMessage](https://developer.mozilla.org/en-US/d
 for this `postMessage` call should be the opener, accessible via
 [window.opener](https://developer.mozilla.org/en-US/docs/Web/API/Window/opener).
 
-Note that for security purposes, the _origin_ of the event (which is added to the event by the browser) needs to match the `serverUrl`
-registered to the app. That is, the origin serving the `authenticationUrl` response must match the app's configured `serverUrl`.
-This is different from the `targetOrigin` of the `window.opener.postMessage` call, which must be exactly `"https://app.asana.com"`.
+Note that for security purposes, the _origin_ of the event (which is added to the event by the browser) needs to match the root of the 
+`authenticationUrl` registered to the app. That is, the authentication response must be served from the same origin that receives the 
+authentication request. This is different from the `targetOrigin` of the `window.opener.postMessage` call, which must be exactly 
+`"https://app.asana.com"`.
 
 ### Additional notes
 

--- a/source/includes/markdown/_13-platform-ui.html.md
+++ b/source/includes/markdown/_13-platform-ui.html.md
@@ -401,7 +401,7 @@ for this `postMessage` call should be the opener, accessible via
 [window.opener](https://developer.mozilla.org/en-US/docs/Web/API/Window/opener).
 
 Note that for security purposes, the _origin_ of the event (which is added to the event by the browser) needs to match the root of the 
-`authenticationUrl` registered to the app. That is, the authentication response must be served from the same origin that receives the 
+`authenticationUrl` registered to the app. That is, the authentication success message must be initiated from the same origin that receives the 
 authentication request. This is different from the `targetOrigin` of the `window.opener.postMessage` call, which must be exactly 
 `"https://app.asana.com"`.
 


### PR DESCRIPTION
I made a PR that removes the need for setting a server_url on apps to simplify the authentication process for developers. This PR updates the documentation to reflect that change.

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->