### PR TITLE
Update URL to non-redirect version, remove unneeded ruby builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [2.5, 2.6, 2.7, 3.0]
+        ruby-version: [2.6]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [2.6]
+        ruby-version: [2.5]
 
     steps:
     - uses: actions/checkout@v2

--- a/pull_forum_updates.js
+++ b/pull_forum_updates.js
@@ -5,7 +5,7 @@ const docsFilename = './source/includes/markdown/_12_1-news-and-changelog.html.m
 
 let result = "";
 
-https.get("https://forum.asana.com/c/developersapi/platform-news/97.json", res => {
+https.get("https://forum.asana.com/c/api/news/97.json", res => {
   res.setEncoding("utf8");
   let body = "";
   res.on("data", data => {


### PR DESCRIPTION
`pull_forum_updates.js` gets run during `make docs_gen`, but will fail because the old URL redirects. Updating the URL to the redirected URL.

I also changed the build to only run against ruby 2.5 since that's what we actually use