### PR TITLE
Update API Reference overviews for App Components and core API.

### DIFF
--- a/source/includes/api-reference/_index.html.md
+++ b/source/includes/api-reference/_index.html.md
@@ -14,8 +14,10 @@ Base URLs:
 
 * <a href="https://app.asana.com/api/1.0">https://app.asana.com/api/1.0</a>
 
-<a href="https://asana.com/terms">Terms of service</a>
-Web: <a href="https://asana.com/support">Asana Support</a> 
+Additional resources:
+
+* <a href="https://asana.com/terms">Terms & Policies</a>
+* <a href="https://asana.com/support">Asana Support</a> 
 </section><hr class="full-line">
 <section class="full-section">
 <a id="asana-attachments"></a>

--- a/source/includes/ui-hooks-reference/_index.html.md
+++ b/source/includes/ui-hooks-reference/_index.html.md
@@ -14,10 +14,14 @@ This is the interface for handling requests for [App Components](https://develop
 
 Base URLs:
 
-* <a href="{siteUrl}">{siteUrl}</a>
+* {siteUrl}
 
-<a href="https://asana.com/terms">Terms of service</a>
-Web: <a href="https://asana.com/support">Asana Support</a> 
+Note that <i>{siteUrl}</i> refers to the base URL for your [App Server](/docs/app-server) endpoints.
+
+Additional resources:
+
+* <a href="https://asana.com/terms">Terms & Policies</a>
+* <a href="https://asana.com/support">Asana Support</a> 
 </section><hr class="full-line">
 <section class="full-section">
 <a id="asana-modal-forms"></a>

--- a/source/templates/main.dot
+++ b/source/templates/main.dot
@@ -18,7 +18,13 @@
 {{? data.api.servers }}
 Base URLs:
 {{~data.api.servers :s}}
+
+{{? s.url === "{siteUrl}" }}
+* {{=s.url}}
+{{??}}
 * <a href="{{=s.url}}">{{=s.url}}</a>
+{{?}}
+
 {{ for(var v in s.variables) { }}
     * **{{=v}}** - {{=s.variables[v].description||''}} Default: {{=s.variables[v].default}}
 {{? s.variables[v].enum}}
@@ -30,8 +36,14 @@ Base URLs:
 {{~}}
 {{?}}
 
-{{? data.api.info && data.api.info.termsOfService}}<a href="{{=data.api.info.termsOfService}}">Terms of service</a>{{?}}
-{{? data.api.info && data.api.info.contact}}{{? data.api.info.contact.email}}Email: <a href="mailto:{{=data.api.info.contact.email}}">{{=data.api.info.contact.name || 'Support'}}</a> {{?}}{{? data.api.info.contact.url}}Web: <a href="{{=data.api.info.contact.url}}">{{= data.api.info.contact.name || 'Support'}}</a> {{?}}{{?}}
+{{? s.url === "{siteUrl}" }}
+Note that <i>{siteUrl}</i> refers to the base URL for your [App Server](/docs/app-server) endpoints.
+{{?}}
+
+Additional resources:
+
+{{? data.api.info && data.api.info.termsOfService}}* <a href="{{=data.api.info.termsOfService}}">Terms & Policies</a>{{?}}
+{{? data.api.info && data.api.info.contact}}{{? data.api.info.contact.email}}Email: <a href="mailto:{{=data.api.info.contact.email}}">{{=data.api.info.contact.name || 'Support'}}</a> {{?}}{{? data.api.info.contact.url}}* <a href="{{=data.api.info.contact.url}}">{{= data.api.info.contact.name || 'Support'}}</a> {{?}}{{?}}
 </section>{{ for (var r in data.resources) { }}{{ data.resource = data.resources[r]; }}<hr class="full-line">
 <section class="full-section">
 <a id="asana-{{=data.utils.slugify(r)}}"></a>


### PR DESCRIPTION
- Removes erroneous link for `{siteUrl}` (i.e., it should _not_ be a link)
- Cleans up presentation of terms and support links

-----

Current:
![Screen Shot 2022-03-21 at 11 57 46 AM](https://user-images.githubusercontent.com/82971401/159345399-d46d0566-8481-4c73-8f99-34ae646c7bbd.png)
![Screen Shot 2022-03-21 at 11 57 29 AM](https://user-images.githubusercontent.com/82971401/159345403-799b9123-d82d-48bc-87c4-3916b1f56042.png)

Updated:
![Screen Shot 2022-03-21 at 11 54 28 AM](https://user-images.githubusercontent.com/82971401/159345466-18ce7129-d781-40e3-8dc7-660c8f5e4df2.png)
![Screen Shot 2022-03-21 at 11 54 59 AM](https://user-images.githubusercontent.com/82971401/159345475-4210c9e0-b409-4f06-9cf8-f2b543c90dbd.png)


