### PR TITLE
App Components Getting Started Video

### DIFF
--- a/source/includes/markdown/_13-platform-ui.html.md
+++ b/source/includes/markdown/_13-platform-ui.html.md
@@ -23,7 +23,14 @@ Using App Components, you can build customizable in-product experiences for apps
 * [Rule Action](/docs/rule-action)
 * [Entry Point](/docs/entry-point)
 
-<img src="../images/UI_Components.gif" />
+For a visual tour on getting started with App Components, feel free to review the following video. Then, when you're ready, visit our [Getting Started](/docs/getting-started) guide to begin building right away.
+
+<div style="padding:35% 0 0 0;position:relative;width:52%">
+  <iframe src="https://player.vimeo.com/video/708387216?h=3f025d1b75&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen style="position:absolute;top:0;left:0;width:100%;height:100%;" title="App Components: Getting Started">
+  </iframe>
+</div>
+
+<script src="https://player.vimeo.com/api/player.js"></script>
 
 **App Components are currently in open beta**. For the latest updates and announcements,
 [subscribe to our developer forum](https://forum.asana.com/c/api/app-components-beta/150).


### PR DESCRIPTION
Replaces animated GIF in the Overview of App Components with a video tutorial.
<img width="1582" alt="Screen Shot 2022-05-10 at 10 36 33 PM" src="https://user-images.githubusercontent.com/82971401/167776636-fe4e4f80-8d64-4a70-bfa1-807205ae0ba5.png">

Responsive for desktop/laptop/tablet, but mobile will need to full-screen the video.
