### PR TITLE
Update AC widget metadata footer response example

### DIFF
--- a/source/includes/markdown/_13-platform-ui.html.md
+++ b/source/includes/markdown/_13-platform-ui.html.md
@@ -56,7 +56,10 @@ https://app-server.com/widget?workspace=12345&task=23456&user=34567&locale=en&at
         "title": "MSB-3 As a user, I see a flexible widget",
         "subtitle": "Jira Cloud Story · Open in Jira Cloud",
         "subicon_url": "https://jira.com/icons/subicon.png",
-        "footer": "Last updated in Jira Cloud 10 minutes ago",
+        "footer": {
+          "footer_type": "updated",
+          "last_updated_at": "2012-02-22T02:06:58.147Z"
+        },
         "comment_count": 12,
         "fields": [
             {


### PR DESCRIPTION
- Update value for footer property for widget metadata in example response. This is inconsistent with our documentation for footer value in the widget metadata schema and should be one of the footer objects listed and not a string.

![updated_widget_footer_value](https://user-images.githubusercontent.com/99784540/172711937-b9f3ed9a-4771-4b15-b727-533aca2596a6.jpg)

