### PR TITLE
Rename General Guidelines to Publishing Checklist for AC under Publis…

### DIFF
--- a/source/includes/markdown/_13-platform-ui.html.md
+++ b/source/includes/markdown/_13-platform-ui.html.md
@@ -617,7 +617,7 @@ Apps built on App Components are manually reviewed before they are accessible wi
 
 <hr>
 
-## General Guidelines
+## Publishing Checklist
 
 <span class="beta-indicator">BETA</span> - For access, please see [Overview of App Components](/docs/overview-of-app-components)
 


### PR DESCRIPTION
- Renamed "General Guidelines" to "Publishing Checklist" under App Components > Publishing an App section