### PR TITLE
Update description for workspace typeahead query description

### DIFF
--- a/defs/asana_oas.yaml
+++ b/defs/asana_oas.yaml
@@ -12694,8 +12694,7 @@ paths:
         in: query
         description: >-
           The string that will be used to search for relevant objects. If an
-          empty string is passed in, the API will currently return an empty
-          result set.
+          empty string is passed in, the API will return results.
         schema:
           type: string
         example: Greg

--- a/source/includes/api-reference/_index.html.md
+++ b/source/includes/api-reference/_index.html.md
@@ -23323,7 +23323,7 @@ projects that are relevant for the requesting user's api token.
 |/workspace_gid<span class="param-type"> string</span><div class="param-required">required</div>|Globally unique identifier for the workspace or organization.|
 |?resource_type<span class="param-type"> string</span><div class="param-required">required</div>|The type of values the typeahead should return. You can choose from one of the following: `custom_field`, `project`, `project_template`, `portfolio`, `tag`, `task`, and `user`. Note that unlike in the names of endpoints, the types listed here are in singular form (e.g. `task`). Using multiple types is not yet supported.|
 |?type<span class="param-type"> string</span>|*Deprecated: new integrations should prefer the resource_type field.*|
-|?query<span class="param-type"> string</span>|The string that will be used to search for relevant objects. If an empty string is passed in, the API will currently return an empty result set.|
+|?query<span class="param-type"> string</span>|The string that will be used to search for relevant objects. If an empty string is passed in, the API will return results.|
 |?count<span class="param-type"> integer</span>|The number of results to return. The default is 20 if this parameter is omitted, with a minimum of 1 and a maximum of 100. If there are fewer results found than requested, all will be returned.|
 |?opt_pretty<span class="param-type"> boolean</span>|Provides “pretty” output.|
 |?opt_fields<span class="param-type"> array[string]</span>|Defines fields to return.|


### PR DESCRIPTION
- Update description for workspace typeahead to say that results are return for query with empty string value which is the expected behavior not an empty result set