### PR TITLE
Fix allowfullscreen warning in dev console

### DIFF
--- a/source/includes/markdown/_13-platform-ui.html.md
+++ b/source/includes/markdown/_13-platform-ui.html.md
@@ -26,7 +26,7 @@ Using App Components, you can build customizable in-product experiences for apps
 For a visual tour on getting started with App Components, feel free to review the following video. Then, when you're ready, visit our [Getting Started](/docs/getting-started) guide to begin building right away.
 
 <div style="padding:35% 0 0 0;position:relative;width:52%">
-  <iframe src="https://player.vimeo.com/video/708387216?h=3f025d1b75&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen style="position:absolute;top:0;left:0;width:100%;height:100%;" title="App Components: Getting Started">
+  <iframe src="https://player.vimeo.com/video/708387216?h=3f025d1b75&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" style="position:absolute;top:0;left:0;width:100%;height:100%;" title="App Components: Getting Started">
   </iframe>
 </div>
 

--- a/source/includes/markdown/_18-webhooks.html.md
+++ b/source/includes/markdown/_18-webhooks.html.md
@@ -38,7 +38,7 @@ The following video tutorial walks you through the process of:
 4. Verifying and [Receiving webhook events](/docs/receiving-events)[9:02]
 
 <div style="padding:35% 0 0 0;position:relative;width:52%">
-  <iframe src="https://player.vimeo.com/video/721606792?h=5d8cdb532f&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen style="position:absolute;top:0;left:0;width:100%;height:100%;" title="Setting Up a Webhook">
+  <iframe src="https://player.vimeo.com/video/721606792?h=5d8cdb532f&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" style="position:absolute;top:0;left:0;width:100%;height:100%;" title="Setting Up a Webhook">
   </iframe>
 </div>
 


### PR DESCRIPTION
Remove `allowfullscreen` from vimeo iframe as it is not needed according to the [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe). I tested the docs locally and was able to fullscreen the player since we have `fullscreen` defined.

<img width="1705" alt="allowfullscreen_warning" src="https://user-images.githubusercontent.com/99784540/187741053-ed82e24f-a72d-4e10-a4ea-916ba90b5a60.png">
<img width="1706" alt="mdn_web_docs_allow_full_screen" src="https://user-images.githubusercontent.com/99784540/187741257-3817da89-ce52-49af-a367-6fc8e4f04031.png">
