### PR TITLE
Added workspace_baa_signed Audit Log event

### DIFF
--- a/source/includes/markdown/_12-audit-log.html.md
+++ b/source/includes/markdown/_12-audit-log.html.md
@@ -74,6 +74,8 @@ All admin settings events operate on the _workspace_ resource type except for `w
 | workspace_form_is_embeddable_forms_disabled          | Embeddable forms is disabled in admin |
 | workspace_logged_out_view_authentication_required_enabled | For this workspace, logged out view link authentication was set as required, so all viewers need to authenticate with Asana in order to open logged out view links. |
 | workspace_logged_out_view_authentication_required_disabled | For this workspace, logged out view link authentication was set as not required, however authentication may still be required for individual links. Some viewers may not need to authenticate with Asana in order to open logged out view links. |
+| workspace_baa_signed                                 | The workspaces’s Business Associate Addendum (BAA) was signed. |
+
 
 ### Roles
  


### PR DESCRIPTION
Assuming I did this correctly, this just adds our new workspace_baa_signed audit log event to the developer docs.


<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->
