### PR TITLE
Add team admins properties to public API docs

### DIFF
--- a/defs/asana_oas.yaml
+++ b/defs/asana_oas.yaml
@@ -5640,10 +5640,10 @@ components:
               $ref: '#/components/schemas/UserCompact'
             team:
               $ref: '#/components/schemas/TeamCompact'
-            is_guest:
+            is_limited_access:
               type: boolean
               description: >-
-                Describes if the user is a guest in the team.
+                Describes if the user has limited access to the team.
               example: false
     TeamMembershipResponse:
       $ref: '#/components/schemas/TeamMembershipBase'
@@ -5689,6 +5689,48 @@ components:
                 - secret
                 - request_to_join
                 - public
+            edit_team_name_or_description_access_level:
+              description: >
+                  Controls who can edit team name and description
+              type: string
+              enum:
+                - all_team_members
+                - only_team_admins
+            edit_team_visibility_or_trash_team_access_level:
+              description: >
+                  Controls who can edit team visibility and trash teams
+              type: string
+              enum:
+                - all_team_members
+                - only_team_admins
+            member_invite_management_access_level:
+              description: >
+                  Controls who can accept or deny member invites for a given team
+              type: string
+              enum:
+                - all_team_members
+                - only_team_admins
+            guest_invite_management_access_level:
+              description: >
+                  Controls who can accept or deny guest invites for a given team
+              type: string
+              enum:
+                - all_team_members
+                - only_team_admins
+            join_request_management_access_level:
+              description: >
+                  Controls who can accept or deny join team requests for a Membership by Request team
+              type: string
+              enum:
+                - all_team_members
+                - only_team_admins
+            team_member_removal_access_level:
+              description: >
+                  Controls who can remove team members
+              type: string
+              enum:
+                - all_team_members
+                - only_team_admins
     TeamResponse:
       allOf:
         - $ref: '#/components/schemas/TeamBase'
@@ -5730,6 +5772,48 @@ components:
                 - secret
                 - request_to_join
                 - public
+            edit_team_name_or_description_access_level:
+              description: >
+                  Controls who can edit team name and description
+              type: string
+              enum:
+                - all_team_members
+                - only_team_admins
+            edit_team_visibility_or_trash_team_access_level:
+              description: >
+                  Controls who can edit team visibility and trash teams
+              type: string
+              enum:
+                - all_team_members
+                - only_team_admins
+            member_invite_management_access_level:
+              description: >
+                  Controls who can accept or deny member invites for a given team
+              type: string
+              enum:
+                - all_team_members
+                - only_team_admins
+            guest_invite_management_access_level:
+              description: >
+                  Controls who can accept or deny guest invites for a given team
+              type: string
+              enum:
+                - all_team_members
+                - only_team_admins
+            join_request_management_access_level:
+              description: >
+                  Controls who can accept or deny join team requests for a Membership by Request team
+              type: string
+              enum:
+                - all_team_members
+                - only_team_admins
+            team_member_removal_access_level:
+              description: >
+                  Controls who can remove team members
+              type: string
+              enum:
+                - all_team_members
+                - only_team_admins
     TimePeriodBase:
       allOf:
         - $ref: '#/components/schemas/TimePeriodCompact'


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

Update docs to add team admins properties that will be exposed to the public API in this [PR](https://github.com/Asana/codez/pull/179314/files)

Asana task: https://app.asana.com/0/1202192145285268/1202916037482272/f