### PR TITLE
Redirect to current API explorer

### DIFF
--- a/source/explorer/index.html
+++ b/source/explorer/index.html
@@ -1,505 +1,703 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE html PUBLIC "-//IETF//DTD HTML//EN">
 <html>
-<head>
-    <title>Asana API Explorer</title>
-    <script src="../javascripts/explorer/asana-explorer.js"></script>
-    <link rel="stylesheet" type="text/css" href="../stylesheets/index.css"/>
-    <link href="https://assets.asana.biz/m/7a38ea1bc15b234a/original/asana-ico.ico" rel="icon" type="image/ico" />
+  <head>
+    <title>Asana API Explorer (legacy)</title>
+    <link rel="stylesheet" type="text/css" href="../stylesheets/index.css" />
+    <link
+      href="https://assets.asana.biz/m/7a38ea1bc15b234a/original/asana-ico.ico"
+      rel="icon"
+      type="image/ico"
+    />
     <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-58LRF8N');</script>
+    <!-- <script>
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != "dataLayer" ? "&l=" + l : "";
+        j.async = true;
+        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, "script", "dataLayer", "GTM-58LRF8N");
+    </script> -->
     <!-- End Google Tag Manager -->
-</head>
+    <script>
+      const newSiteURL = "https://developers.asana.com/docs/api-explorer";
 
-<body>
-<div class="header">
-  <a href="/">
-    <img src="https://assets.asana.biz/m/33a0924d61aabd7b/original/Asana-developers-lockup-horizontal.svg" class="logo" alt="Logo">
-  </a>
-</div>
-<div id="tab-explorer">Loading react...</div>
+      function redirectToNewSite() {
+        window.location.href = newSiteURL;
+      }
 
-<script>
-    if (window.location.host !== "developers-legacy.asana.com") {
-      window.location.href = "https://developers-legacy.asana.com/explorer";
-    }
-    AsanaExplorer.Explorer.run();
-</script>
+      setTimeout(redirectToNewSite, 8500);
 
-<footer class="siteFooter">
-  <div class="siteFooter__main__wrapper py-2 py-sm-5">
-    <div class="container -wide">
-      <div class="siteFooter__row">
-        <div class="siteFooter__logo mb-3 mb-md-0">
-          <a href="https://asana.com/?noredirect" class="siteFooter__logo-icon">
-            <span class="sr-only">Asana Logo</span>
-            <svg class="icon-svg icon-svg--dots icon--white" width="10" height="10" viewBox="0 0 32 32" preserveAspectRatio="xMinYMin">
-              <path d="M23.1,8.1c0,3.8-3.1,6.9-7,6.9s-7-3.1-7-6.9c0-3.8,3.1-6.9,7-6.9S23.1,4.3,23.1,8.1C23.1,8.1,23.1,8.1,23.1,8.1z M7.1,16.7c-3.8,0-7,3.1-7,6.9s3.1,6.9,7,6.9s7-3.1,7-6.9S10.9,16.7,7.1,16.7C7.1,16.7,7.1,16.7,7.1,16.7z M25.1,16.7c-3.8,0-7,3.1-7,6.9s3.1,6.9,7,6.9s7-3.1,7-6.9S29,16.7,25.1,16.7C25.1,16.7,25.1,16.7,25.1,16.7z"/>
-            </svg>
-          </a>
-        </div>
-        <ul class="siteFooter__list">
-          <li class="siteFooter__title">Asana</li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/?noredirect" class="-white">Home</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/product" class="-white">Product</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/pricing" class="-white">Pricing</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/premium" class="-white">Premium</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/business" class="-white">Business</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/enterprise" class="-white">Enterprise</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/customer-success" class="-white">Customer Success</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/templates" class="-white">Asana Templates</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/trust" class="-white">Trust &amp; Security</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://status.asana.com" class="-white" target="_blank" rel="noopener noreferrer">Status</a>
-          </li>
-        </ul>
-        <ul class="siteFooter__list">
-          <li class="siteFooter__title">About Us</li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/company" class="-white">Company</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/leadership" class="-white">Leadership</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/customers" class="-white">Customers</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/diversity-and-inclusion" class="-white">Diversity</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/jobs" class="-white">Careers</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/press" class="-white">Press</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://wavelength.asana.com/" class="-white" target="_blank" rel="noopener noreferrer">Wavelength</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://blog.asana.com" class="-white" target="_blank" rel="noopener noreferrer">Asana Blog</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/site-map" class="-white">Sitemap</a>
-          </li>
-        </ul>
-        <ul class="siteFooter__list">
-          <li class="siteFooter__title">Workflow Solutions</li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/uses/project-management" class="-white">Project Management</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/product/goals" class="-white">Goal Management</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/uses/agile-management" class="-white">Agile and Scrum</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/uses/task-management" class="-white">Task Management</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/uses/increase-productivity" class="-white">Increase Productivity</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/uses/work-management" class="-white">Work Management</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/uses" class="-white">See All Uses</a>
-          </li>
-        </ul>
-        <ul class="siteFooter__list">
-          <li class="siteFooter__title">Team Solutions</li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/teams/engineering" class="-white">Engineering</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/teams/designers" class="-white">Designers</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/teams/sales" class="-white">Sales</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/teams/hr" class="-white">HR</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/teams/marketing" class="-white">Marketing</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/teams/company-wide" class="-white">Company-wide</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/teams" class="-white">See All Teams</a>
-          </li>
-        </ul>
-        <ul class="siteFooter__list">
-          <li class="siteFooter__title">Resources</li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/guide" class="-white">Asana Guide</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://forum.asana.com" class="-white" target="_blank" rel="noopener noreferrer">Forum</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/support" class="-white">Support</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/apps" class="-white">Integrations</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://developers.asana.com/docs/" class="-white" target="_blank" rel="noopener noreferrer">Developers &amp; API</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/partners" class="-white">Partners</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://asana.com/community" class="-white">Asana Community</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://certifiedpros.asana.com/" class="-white" target="_blank" rel="noopener noreferrer">Certified Pros</a>
-          </li>
-          <li class="siteFooter__item">
-            <a href="https://events.asana.com/" class="-white" target="_blank" rel="noopener noreferrer">Events</a>
-          </li>
-        </ul>
-      </div>
+      document.getElementById("new-site-link").href = newSiteURL;
+    </script>
+  </head>
+
+  <body>
+    <div class="header">
+      <a href="/">
+        <img
+          src="https://assets.asana.biz/m/33a0924d61aabd7b/original/Asana-developers-lockup-horizontal.svg"
+          class="logo"
+          alt="Logo"
+        />
+      </a>
     </div>
-  </div>
-  <div class="siteFooter__secondary__wrapper">
-    <div class="container -wide">
-      <div class="siteFooter__row">
-        <div class="siteFooter__secondary__col-wrapper">
-          <div class="siteFooter__secondary__col siteFooter__secondary__col--terms">
-            <a href="https://asana.com/terms" title="Terms &amp; Privacy" class="-white">
-              Terms &amp; Privacy
-            </a>
-          </div>
-          <div class="siteFooter__secondary__col siteFooter__secondary__col--social">
-            <a href="https://twitter.com/intent/follow?screen_name=asana" target="_blank" rel="noopener noreferrer">
-              <img src="https://luna1.co/twitter_icon-circle.svg" alt="twitter">
-            </a>
-            <a href="https://www.linkedin.com/company/asana" target="_blank" rel="noopener noreferrer">
-              <img src="https://luna1.co/linkedin_icon-circle.svg" alt="linkedin">
-            </a>
-            <a href="https://www.instagram.com/asana" target="_blank" rel="noopener noreferrer">
-              <img src="https://luna1.co/instagram_icon-circle.svg" alt="instagram">
-            </a>
-            <a href="https://www.facebook.com/asana" target="_blank" rel="noopener noreferrer">
-              <img src="https://luna1.co/facebook_icon-circle.svg" alt="facebook">
-            </a>
-            <a href="https://www.youtube.com/channel/UC2BoogM0AqwOJyoSp1S4ClQ" target="_blank" rel="noopener noreferrer">
-              <img src="https://luna1.co/youtube_icon-circle.svg" alt="youtube">
-            </a>
-          </div>
-          <div class="siteFooter__secondary__col">
-            <a href="https://itunes.apple.com/us/app/asana-mobile/id489969512?mt=8" data-ois-button="" class="siteFooter-mobile-button">
-              <img src="https://luna1.co/Download_App_Store_Badge_US.svg" alt="Download App Button" title="Download App">
-            </a>
-            <a href="https://play.google.com/store/apps/details?id=com.asana.app&amp;referrer=noredirect" data-android-button="" class="siteFooter-mobile-button">
-              <img src="https://luna1.co/Google_Play_EN.svg" alt="Download App Button" title="Download App">
-            </a>
+
+    <div id="message">
+      <h1>Asana API Explorer (legacy)</h1>
+      <p>You have arrived at the legacy API Explorer page.</p>
+      <p>
+        This tool is no longer supported. You will be redirected to the new API
+        Explorer shortly.
+      </p>
+      <p>
+        If you are not redirected automatically, please visit
+        <a
+          id="new-site-link"
+          href="https://developers.asana.com/docs/api-explorer"
+          >the new site</a
+        >.
+      </p>
+    </div>
+
+    <footer class="siteFooter">
+      <div class="siteFooter__main__wrapper py-2 py-sm-5">
+        <div class="container -wide">
+          <div class="siteFooter__row">
+            <div class="siteFooter__logo mb-3 mb-md-0">
+              <a
+                href="https://asana.com/?noredirect"
+                class="siteFooter__logo-icon"
+              >
+                <span class="sr-only">Asana Logo</span>
+                <svg
+                  class="icon-svg icon-svg--dots icon--white"
+                  width="10"
+                  height="10"
+                  viewBox="0 0 32 32"
+                  preserveAspectRatio="xMinYMin"
+                >
+                  <path
+                    d="M23.1,8.1c0,3.8-3.1,6.9-7,6.9s-7-3.1-7-6.9c0-3.8,3.1-6.9,7-6.9S23.1,4.3,23.1,8.1C23.1,8.1,23.1,8.1,23.1,8.1z M7.1,16.7c-3.8,0-7,3.1-7,6.9s3.1,6.9,7,6.9s7-3.1,7-6.9S10.9,16.7,7.1,16.7C7.1,16.7,7.1,16.7,7.1,16.7z M25.1,16.7c-3.8,0-7,3.1-7,6.9s3.1,6.9,7,6.9s7-3.1,7-6.9S29,16.7,25.1,16.7C25.1,16.7,25.1,16.7,25.1,16.7z"
+                  />
+                </svg>
+              </a>
+            </div>
+            <ul class="siteFooter__list">
+              <li class="siteFooter__title">Asana</li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/?noredirect" class="-white">Home</a>
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/product" class="-white">Product</a>
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/pricing" class="-white">Pricing</a>
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/premium" class="-white">Premium</a>
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/business" class="-white">Business</a>
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/enterprise" class="-white"
+                  >Enterprise</a
+                >
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/customer-success" class="-white"
+                  >Customer Success</a
+                >
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/templates" class="-white"
+                  >Asana Templates</a
+                >
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/trust" class="-white"
+                  >Trust &amp; Security</a
+                >
+              </li>
+              <li class="siteFooter__item">
+                <a
+                  href="https://status.asana.com"
+                  class="-white"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >Status</a
+                >
+              </li>
+            </ul>
+            <ul class="siteFooter__list">
+              <li class="siteFooter__title">About Us</li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/company" class="-white">Company</a>
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/leadership" class="-white"
+                  >Leadership</a
+                >
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/customers" class="-white"
+                  >Customers</a
+                >
+              </li>
+              <li class="siteFooter__item">
+                <a
+                  href="https://asana.com/diversity-and-inclusion"
+                  class="-white"
+                  >Diversity</a
+                >
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/jobs" class="-white">Careers</a>
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/press" class="-white">Press</a>
+              </li>
+              <li class="siteFooter__item">
+                <a
+                  href="https://wavelength.asana.com/"
+                  class="-white"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >Wavelength</a
+                >
+              </li>
+              <li class="siteFooter__item">
+                <a
+                  href="https://blog.asana.com"
+                  class="-white"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >Asana Blog</a
+                >
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/site-map" class="-white">Sitemap</a>
+              </li>
+            </ul>
+            <ul class="siteFooter__list">
+              <li class="siteFooter__title">Workflow Solutions</li>
+              <li class="siteFooter__item">
+                <a
+                  href="https://asana.com/uses/project-management"
+                  class="-white"
+                  >Project Management</a
+                >
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/product/goals" class="-white"
+                  >Goal Management</a
+                >
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/uses/agile-management" class="-white"
+                  >Agile and Scrum</a
+                >
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/uses/task-management" class="-white"
+                  >Task Management</a
+                >
+              </li>
+              <li class="siteFooter__item">
+                <a
+                  href="https://asana.com/uses/increase-productivity"
+                  class="-white"
+                  >Increase Productivity</a
+                >
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/uses/work-management" class="-white"
+                  >Work Management</a
+                >
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/uses" class="-white">See All Uses</a>
+              </li>
+            </ul>
+            <ul class="siteFooter__list">
+              <li class="siteFooter__title">Team Solutions</li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/teams/engineering" class="-white"
+                  >Engineering</a
+                >
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/teams/designers" class="-white"
+                  >Designers</a
+                >
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/teams/sales" class="-white">Sales</a>
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/teams/hr" class="-white">HR</a>
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/teams/marketing" class="-white"
+                  >Marketing</a
+                >
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/teams/company-wide" class="-white"
+                  >Company-wide</a
+                >
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/teams" class="-white"
+                  >See All Teams</a
+                >
+              </li>
+            </ul>
+            <ul class="siteFooter__list">
+              <li class="siteFooter__title">Resources</li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/guide" class="-white">Asana Guide</a>
+              </li>
+              <li class="siteFooter__item">
+                <a
+                  href="https://forum.asana.com"
+                  class="-white"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >Forum</a
+                >
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/support" class="-white">Support</a>
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/apps" class="-white">Integrations</a>
+              </li>
+              <li class="siteFooter__item">
+                <a
+                  href="https://developers.asana.com/docs/"
+                  class="-white"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >Developers &amp; API</a
+                >
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/partners" class="-white">Partners</a>
+              </li>
+              <li class="siteFooter__item">
+                <a href="https://asana.com/community" class="-white"
+                  >Asana Community</a
+                >
+              </li>
+              <li class="siteFooter__item">
+                <a
+                  href="https://certifiedpros.asana.com/"
+                  class="-white"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >Certified Pros</a
+                >
+              </li>
+              <li class="siteFooter__item">
+                <a
+                  href="https://events.asana.com/"
+                  class="-white"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >Events</a
+                >
+              </li>
+            </ul>
           </div>
         </div>
       </div>
-    </div>
-  </div>
-</footer>
-<style>
-  .siteFooter a {
-    cursor: auto;
-  }
-  .siteFooter ::selection {
-    background-color: #95e0ff;
-    color: #222b37;
-    text-shadow: none;
-  }
-  .siteFooter a {
-    background-color: transparent;
-    color: #796eff;
-    cursor: pointer;
-    font-weight: 500;
-    text-decoration: none;
-    transition: color 0.3s;
-  }
-  .siteFooter a:hover {
-    border-bottom: 2px solid #635ac7;
-    color: #635ac7;
-    text-decoration: none;
-  }
-  .siteFooter a.-white {
-    border-bottom: 2px solid #edf1f2;
-    color: #fff;
-  }
-  .siteFooter a.-white:hover {
-    border-bottom-color: #fff;
-  }
-  .siteFooter .container {
-    box-sizing: border-box;
-    margin-left: auto;
-    margin-right: auto;
-    transition: width 0.15s;
-    width: calc(100% - 64px);
-  }
-  .siteFooter .container.-wide {
-    max-width: 1312px;
-    width: calc(100% - 128px);
-  }
-  @media (max-width: 48em) {
-    .siteFooter .container.-wide {
-      width: calc(100% - 96px);
-    }
-  }
-  @media (max-width: 30em) {
-    .siteFooter .container.-wide {
-      width: calc(100% - 32px);
-    }
-  }
-  .siteFooter ul {
-    box-sizing: border-box;
-    list-style-type: disc;
-    margin: 0;
-    margin-bottom: 32px;
-    padding-left: 32px;
-  }
-  .siteFooter ul li {
-    margin-bottom: 8px;
-    position: relative;
-  }
-  .siteFooter :last-child {
-    margin-bottom: 0 !important;
-  }
-  .siteFooter .icon--white {
-    color: #fff;
-  }
-  .siteFooter li {
-    list-style-type: none;
-  }
-  .siteFooter a {
-    font-size: 14px;
-  }
-  .siteFooter a.-white {
-    color: #fff;
-    border-bottom: none;
-    font-weight: 400;
-  }
-  .siteFooter a.-white:hover {
-    border-bottom: 1px solid #fff;
-  }
-  .siteFooter .siteFooter__row {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-  }
-  .siteFooter .siteFooter__logo {
-    box-sizing: border-box;
-    flex-basis: 100%;
-    padding: 0 15px;
-  }
-  @media (min-width: 60em) {
-    .siteFooter .siteFooter__logo {
-      flex-basis: 8.33333%;
-    }
-  }
-  .siteFooter .siteFooter__logo-icon {
-    display: inline-block;
-    position: relative;
-    height: 25px;
-    width: 25px;
-  }
-  .siteFooter .siteFooter__logo-icon:before {
-    content: "";
-    display: block;
-    width: 35px;
-    height: 35px;
-    position: absolute;
-    background: #222b37;
-    border-radius: 3px;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    opacity: 0;
-    z-index: 0;
-    border: 3px solid transparent;
-    transition: opacity 0.2s ease-in-out, outline-color 0.2s ease-in-out;
-  }
-  .siteFooter .siteFooter__logo-icon:hover {
-    border: none;
-  }
-  .siteFooter .siteFooter__logo-icon:hover:before {
-    opacity: 1;
-  }
-  .siteFooter .siteFooter__logo-icon:focus {
-    outline: none;
-  }
-  .siteFooter .siteFooter__logo-icon:focus:before {
-    opacity: 1;
-    border-color: #fff;
-  }
-  .siteFooter .siteFooter__logo-icon svg {
-    height: 24px;
-    width: 24px;
-    position: relative;
-    z-index: 1;
-  }
-  .siteFooter .siteFooter__list {
-    flex-basis: 50%;
-    padding: 0 15px;
-    margin-bottom: 64px;
-  }
-  @media (min-width: 48em) {
-    .siteFooter .siteFooter__list {
-      flex-basis: 33.33333%;
-    }
-  }
-  @media (min-width: 60em) {
-    .siteFooter .siteFooter__list {
-      flex-basis: 25%;
-    }
-    .siteFooter .siteFooter__list:nth-of-type(4) {
-      margin-left: 8.33333%;
-    }
-  }
-  @media (min-width: 70em) {
-    .siteFooter .siteFooter__list {
-      flex-basis: 16.66667%;
-      margin-bottom: 0;
-    }
-    .siteFooter .siteFooter__list:nth-of-type(4) {
-      margin-left: 0;
-    }
-  }
-  .siteFooter .siteFooter__title {
-    color: #9ca6af;
-    font-weight: 500;
-    margin-bottom: 32px;
-    font-size: 14px;
-  }
-  .siteFooter .siteFooter__item {
-    hyphens: auto;
-    -webkit-hyphens: auto;
-    -moz-hyphens: auto;
-    word-wrap: break-word;
-    margin-bottom: 14px;
-  }
-  .siteFooter .siteFooter__item:last-child {
-    margin-bottom: 0;
-  }
-  @media (max-width: 59.9375em) {
-    .siteFooter .siteFooter__item {
-      margin-bottom: 12px;
-    }
-    .siteFooter .siteFooter__item a {
-      font-size: 12px;
-    }
-  }
-  .siteFooter .siteFooter__main__wrapper {
-    background-color: #151b26;
-  }
-  @media (min-width: 960px) {
-    .siteFooter .mb-md-0 {
-      margin-bottom: 0 !important;
-    }
-  }
-  .siteFooter .py-2 {
-    padding-top: 32px !important;
-    padding-bottom: 32px !important;
-  }
-  .siteFooter .mb-3 {
-    margin-bottom: 48px !important;
-  }
-  @media (min-width: 768px) {
-    .siteFooter .py-sm-5 {
-      padding-top: 80px !important;
-      padding-bottom: 80px !important;
-    }
-  }
-  .siteFooter .siteFooter__secondary__wrapper {
-    background-color: #222b37;
-    color: #fff;
-    padding-bottom: 32px;
-    padding-top: 32px;
-  }
-  .siteFooter .siteFooter__secondary__col-wrapper {
-    flex-basis: 100%;
-    margin: 0 8.33333%;
-    padding: 0 15px;
-    display: flex;
-    flex-flow: row wrap;
-    justify-content: space-between;
-    align-items: center;
-  }
-  .siteFooter .siteFooter__secondary__col {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    margin-bottom: 32px;
-    flex-basis: 100%;
-  }
-  @media (min-width: 60em) {
-    .siteFooter .siteFooter__secondary__col {
-      margin-bottom: 0;
-      flex-basis: auto;
-    }
-  }
-  .siteFooter .siteFooter__secondary__col--terms {
-    align-items: center;
-  }
-  .siteFooter .siteFooter__secondary__col--social a {
-    font-size: 1.375rem;
-    border-bottom: none;
-    width: 32px;
-    margin: 0 1.5px;
-  }
-  .siteFooter .siteFooter__secondary__col--social a:hover {
-    border-bottom: none !important;
-    filter: invert(1) contrast(2);
-  }
-  .siteFooter .siteFooter-mobile-button {
-    display: block;
-    margin-right: 5px;
-  }
-  .siteFooter .siteFooter-mobile-button:hover {
-    border-bottom: none;
-  }
-  .siteFooter .siteFooter-mobile-button img {
-    height: 40px;
-    opacity: 0.6;
-    transition: opacity 225ms;
-  }
-  .siteFooter .siteFooter-mobile-button img:hover {
-    opacity: 1;
-  }
-  .siteFooter .icon--white path{
-    fill: #fff;
-  }
-  .sr-only {
-    position: absolute !important; /* Outside the DOM flow */
-    height: 1px;
-    width: 1px;
-    overflow: hidden;
-    clip: rect(1px 1px 1px 1px); /* IE 7+ only support clip without commas */
-    clip: rect(1px, 1px, 1px, 1px); /* All other browsers */
-  }
-</style>
-</body>
+      <div class="siteFooter__secondary__wrapper">
+        <div class="container -wide">
+          <div class="siteFooter__row">
+            <div class="siteFooter__secondary__col-wrapper">
+              <div
+                class="siteFooter__secondary__col siteFooter__secondary__col--terms"
+              >
+                <a
+                  href="https://asana.com/terms"
+                  title="Terms &amp; Privacy"
+                  class="-white"
+                >
+                  Terms &amp; Privacy
+                </a>
+              </div>
+              <div
+                class="siteFooter__secondary__col siteFooter__secondary__col--social"
+              >
+                <a
+                  href="https://twitter.com/intent/follow?screen_name=asana"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    src="https://luna1.co/twitter_icon-circle.svg"
+                    alt="twitter"
+                  />
+                </a>
+                <a
+                  href="https://www.linkedin.com/company/asana"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    src="https://luna1.co/linkedin_icon-circle.svg"
+                    alt="linkedin"
+                  />
+                </a>
+                <a
+                  href="https://www.instagram.com/asana"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    src="https://luna1.co/instagram_icon-circle.svg"
+                    alt="instagram"
+                  />
+                </a>
+                <a
+                  href="https://www.facebook.com/asana"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    src="https://luna1.co/facebook_icon-circle.svg"
+                    alt="facebook"
+                  />
+                </a>
+                <a
+                  href="https://www.youtube.com/channel/UC2BoogM0AqwOJyoSp1S4ClQ"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    src="https://luna1.co/youtube_icon-circle.svg"
+                    alt="youtube"
+                  />
+                </a>
+              </div>
+              <div class="siteFooter__secondary__col">
+                <a
+                  href="https://itunes.apple.com/us/app/asana-mobile/id489969512?mt=8"
+                  data-ois-button=""
+                  class="siteFooter-mobile-button"
+                >
+                  <img
+                    src="https://luna1.co/Download_App_Store_Badge_US.svg"
+                    alt="Download App Button"
+                    title="Download App"
+                  />
+                </a>
+                <a
+                  href="https://play.google.com/store/apps/details?id=com.asana.app&amp;referrer=noredirect"
+                  data-android-button=""
+                  class="siteFooter-mobile-button"
+                >
+                  <img
+                    src="https://luna1.co/Google_Play_EN.svg"
+                    alt="Download App Button"
+                    title="Download App"
+                  />
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </footer>
+    <style>
+      #message {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-direction: column;
+      }
+      .siteFooter a {
+        cursor: auto;
+      }
+      .siteFooter ::selection {
+        background-color: #95e0ff;
+        color: #222b37;
+        text-shadow: none;
+      }
+      .siteFooter a {
+        background-color: transparent;
+        color: #796eff;
+        cursor: pointer;
+        font-weight: 500;
+        text-decoration: none;
+        transition: color 0.3s;
+      }
+      .siteFooter a:hover {
+        border-bottom: 2px solid #635ac7;
+        color: #635ac7;
+        text-decoration: none;
+      }
+      .siteFooter a.-white {
+        border-bottom: 2px solid #edf1f2;
+        color: #fff;
+      }
+      .siteFooter a.-white:hover {
+        border-bottom-color: #fff;
+      }
+      .siteFooter .container {
+        box-sizing: border-box;
+        margin-left: auto;
+        margin-right: auto;
+        transition: width 0.15s;
+        width: calc(100% - 64px);
+      }
+      .siteFooter .container.-wide {
+        max-width: 1312px;
+        width: calc(100% - 128px);
+      }
+      @media (max-width: 48em) {
+        .siteFooter .container.-wide {
+          width: calc(100% - 96px);
+        }
+      }
+      @media (max-width: 30em) {
+        .siteFooter .container.-wide {
+          width: calc(100% - 32px);
+        }
+      }
+      .siteFooter ul {
+        box-sizing: border-box;
+        list-style-type: disc;
+        margin: 0;
+        margin-bottom: 32px;
+        padding-left: 32px;
+      }
+      .siteFooter ul li {
+        margin-bottom: 8px;
+        position: relative;
+      }
+      .siteFooter :last-child {
+        margin-bottom: 0 !important;
+      }
+      .siteFooter .icon--white {
+        color: #fff;
+      }
+      .siteFooter li {
+        list-style-type: none;
+      }
+      .siteFooter a {
+        font-size: 14px;
+      }
+      .siteFooter a.-white {
+        color: #fff;
+        border-bottom: none;
+        font-weight: 400;
+      }
+      .siteFooter a.-white:hover {
+        border-bottom: 1px solid #fff;
+      }
+      .siteFooter .siteFooter__row {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+      }
+      .siteFooter .siteFooter__logo {
+        box-sizing: border-box;
+        flex-basis: 100%;
+        padding: 0 15px;
+      }
+      @media (min-width: 60em) {
+        .siteFooter .siteFooter__logo {
+          flex-basis: 8.33333%;
+        }
+      }
+      .siteFooter .siteFooter__logo-icon {
+        display: inline-block;
+        position: relative;
+        height: 25px;
+        width: 25px;
+      }
+      .siteFooter .siteFooter__logo-icon:before {
+        content: "";
+        display: block;
+        width: 35px;
+        height: 35px;
+        position: absolute;
+        background: #222b37;
+        border-radius: 3px;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        opacity: 0;
+        z-index: 0;
+        border: 3px solid transparent;
+        transition: opacity 0.2s ease-in-out, outline-color 0.2s ease-in-out;
+      }
+      .siteFooter .siteFooter__logo-icon:hover {
+        border: none;
+      }
+      .siteFooter .siteFooter__logo-icon:hover:before {
+        opacity: 1;
+      }
+      .siteFooter .siteFooter__logo-icon:focus {
+        outline: none;
+      }
+      .siteFooter .siteFooter__logo-icon:focus:before {
+        opacity: 1;
+        border-color: #fff;
+      }
+      .siteFooter .siteFooter__logo-icon svg {
+        height: 24px;
+        width: 24px;
+        position: relative;
+        z-index: 1;
+      }
+      .siteFooter .siteFooter__list {
+        flex-basis: 50%;
+        padding: 0 15px;
+        margin-bottom: 64px;
+      }
+      @media (min-width: 48em) {
+        .siteFooter .siteFooter__list {
+          flex-basis: 33.33333%;
+        }
+      }
+      @media (min-width: 60em) {
+        .siteFooter .siteFooter__list {
+          flex-basis: 25%;
+        }
+        .siteFooter .siteFooter__list:nth-of-type(4) {
+          margin-left: 8.33333%;
+        }
+      }
+      @media (min-width: 70em) {
+        .siteFooter .siteFooter__list {
+          flex-basis: 16.66667%;
+          margin-bottom: 0;
+        }
+        .siteFooter .siteFooter__list:nth-of-type(4) {
+          margin-left: 0;
+        }
+      }
+      .siteFooter .siteFooter__title {
+        color: #9ca6af;
+        font-weight: 500;
+        margin-bottom: 32px;
+        font-size: 14px;
+      }
+      .siteFooter .siteFooter__item {
+        hyphens: auto;
+        -webkit-hyphens: auto;
+        -moz-hyphens: auto;
+        word-wrap: break-word;
+        margin-bottom: 14px;
+      }
+      .siteFooter .siteFooter__item:last-child {
+        margin-bottom: 0;
+      }
+      @media (max-width: 59.9375em) {
+        .siteFooter .siteFooter__item {
+          margin-bottom: 12px;
+        }
+        .siteFooter .siteFooter__item a {
+          font-size: 12px;
+        }
+      }
+      .siteFooter .siteFooter__main__wrapper {
+        background-color: #151b26;
+      }
+      @media (min-width: 960px) {
+        .siteFooter .mb-md-0 {
+          margin-bottom: 0 !important;
+        }
+      }
+      .siteFooter .py-2 {
+        padding-top: 32px !important;
+        padding-bottom: 32px !important;
+      }
+      .siteFooter .mb-3 {
+        margin-bottom: 48px !important;
+      }
+      @media (min-width: 768px) {
+        .siteFooter .py-sm-5 {
+          padding-top: 80px !important;
+          padding-bottom: 80px !important;
+        }
+      }
+      .siteFooter .siteFooter__secondary__wrapper {
+        background-color: #222b37;
+        color: #fff;
+        padding-bottom: 32px;
+        padding-top: 32px;
+      }
+      .siteFooter .siteFooter__secondary__col-wrapper {
+        flex-basis: 100%;
+        margin: 0 8.33333%;
+        padding: 0 15px;
+        display: flex;
+        flex-flow: row wrap;
+        justify-content: space-between;
+        align-items: center;
+      }
+      .siteFooter .siteFooter__secondary__col {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        margin-bottom: 32px;
+        flex-basis: 100%;
+      }
+      @media (min-width: 60em) {
+        .siteFooter .siteFooter__secondary__col {
+          margin-bottom: 0;
+          flex-basis: auto;
+        }
+      }
+      .siteFooter .siteFooter__secondary__col--terms {
+        align-items: center;
+      }
+      .siteFooter .siteFooter__secondary__col--social a {
+        font-size: 1.375rem;
+        border-bottom: none;
+        width: 32px;
+        margin: 0 1.5px;
+      }
+      .siteFooter .siteFooter__secondary__col--social a:hover {
+        border-bottom: none !important;
+        filter: invert(1) contrast(2);
+      }
+      .siteFooter .siteFooter-mobile-button {
+        display: block;
+        margin-right: 5px;
+      }
+      .siteFooter .siteFooter-mobile-button:hover {
+        border-bottom: none;
+      }
+      .siteFooter .siteFooter-mobile-button img {
+        height: 40px;
+        opacity: 0.6;
+        transition: opacity 225ms;
+      }
+      .siteFooter .siteFooter-mobile-button img:hover {
+        opacity: 1;
+      }
+      .siteFooter .icon--white path {
+        fill: #fff;
+      }
+      .sr-only {
+        position: absolute !important; /* Outside the DOM flow */
+        height: 1px;
+        width: 1px;
+        overflow: hidden;
+        clip: rect(
+          1px 1px 1px 1px
+        ); /* IE 7+ only support clip without commas */
+        clip: rect(1px, 1px, 1px, 1px); /* All other browsers */
+      }
+    </style>
+  </body>
 </html>

--- a/source/explorer/index.html
+++ b/source/explorer/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//IETF//DTD HTML//EN">
 <html>
   <head>
-    <title>Asana API Explorer (legacy)</title>
+    <title>Asana API explorer (legacy)</title>
     <link rel="stylesheet" type="text/css" href="../stylesheets/index.css" />
     <link
       href="https://assets.asana.biz/m/7a38ea1bc15b234a/original/asana-ico.ico"
@@ -34,10 +34,10 @@
 
     <div class="flex-wrapper">
       <div id="message">
-        <h1>Asana API Explorer (legacy)</h1>
+        <h1>Asana API explorer (legacy)</h1>
         <p>
           This tool is no longer supported. You will be redirected to the new
-          API Explorer shortly.
+          API explorer shortly.
         </p>
         <p>
           If you are not redirected automatically, please visit

--- a/source/explorer/index.html
+++ b/source/explorer/index.html
@@ -29,7 +29,7 @@
         window.location.href = newSiteURL;
       }
 
-      setTimeout(redirectToNewSite, 8500);
+      setTimeout(redirectToNewSite, 8000);
 
       document.getElementById("new-site-link").href = newSiteURL;
     </script>
@@ -46,380 +46,409 @@
       </a>
     </div>
 
-    <div id="message">
-      <h1>Asana API Explorer (legacy)</h1>
-      <p>You have arrived at the legacy API Explorer page.</p>
-      <p>
-        This tool is no longer supported. You will be redirected to the new API
-        Explorer shortly.
-      </p>
-      <p>
-        If you are not redirected automatically, please visit
-        <a
-          id="new-site-link"
-          href="https://developers.asana.com/docs/api-explorer"
-          >the new site</a
-        >.
-      </p>
+    <div class="flex-wrapper">
+      <div id="message">
+        <h1>Asana API Explorer (legacy)</h1>
+        <p>
+          This tool is no longer supported. You will be redirected to the new
+          API Explorer shortly.
+        </p>
+        <p>
+          If you are not redirected automatically, please visit
+          <a
+            id="new-site-link"
+            href="https://developers.asana.com/docs/api-explorer"
+            >the new site</a
+          >.
+        </p>
+      </div>
+      <footer class="siteFooter">
+        <div class="siteFooter__main__wrapper py-2 py-sm-5">
+          <div class="container -wide">
+            <div class="siteFooter__row">
+              <div class="siteFooter__logo mb-3 mb-md-0">
+                <a
+                  href="https://asana.com/?noredirect"
+                  class="siteFooter__logo-icon"
+                >
+                  <span class="sr-only">Asana Logo</span>
+                  <svg
+                    class="icon-svg icon-svg--dots icon--white"
+                    width="10"
+                    height="10"
+                    viewBox="0 0 32 32"
+                    preserveAspectRatio="xMinYMin"
+                  >
+                    <path
+                      d="M23.1,8.1c0,3.8-3.1,6.9-7,6.9s-7-3.1-7-6.9c0-3.8,3.1-6.9,7-6.9S23.1,4.3,23.1,8.1C23.1,8.1,23.1,8.1,23.1,8.1z M7.1,16.7c-3.8,0-7,3.1-7,6.9s3.1,6.9,7,6.9s7-3.1,7-6.9S10.9,16.7,7.1,16.7C7.1,16.7,7.1,16.7,7.1,16.7z M25.1,16.7c-3.8,0-7,3.1-7,6.9s3.1,6.9,7,6.9s7-3.1,7-6.9S29,16.7,25.1,16.7C25.1,16.7,25.1,16.7,25.1,16.7z"
+                    />
+                  </svg>
+                </a>
+              </div>
+              <ul class="siteFooter__list">
+                <li class="siteFooter__title">Asana</li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/?noredirect" class="-white"
+                    >Home</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/product" class="-white">Product</a>
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/pricing" class="-white">Pricing</a>
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/premium" class="-white">Premium</a>
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/business" class="-white"
+                    >Business</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/enterprise" class="-white"
+                    >Enterprise</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/customer-success" class="-white"
+                    >Customer Success</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/templates" class="-white"
+                    >Asana Templates</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/trust" class="-white"
+                    >Trust &amp; Security</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a
+                    href="https://status.asana.com"
+                    class="-white"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >Status</a
+                  >
+                </li>
+              </ul>
+              <ul class="siteFooter__list">
+                <li class="siteFooter__title">About Us</li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/company" class="-white">Company</a>
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/leadership" class="-white"
+                    >Leadership</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/customers" class="-white"
+                    >Customers</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a
+                    href="https://asana.com/diversity-and-inclusion"
+                    class="-white"
+                    >Diversity</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/jobs" class="-white">Careers</a>
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/press" class="-white">Press</a>
+                </li>
+                <li class="siteFooter__item">
+                  <a
+                    href="https://wavelength.asana.com/"
+                    class="-white"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >Wavelength</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a
+                    href="https://blog.asana.com"
+                    class="-white"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >Asana Blog</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/site-map" class="-white"
+                    >Sitemap</a
+                  >
+                </li>
+              </ul>
+              <ul class="siteFooter__list">
+                <li class="siteFooter__title">Workflow Solutions</li>
+                <li class="siteFooter__item">
+                  <a
+                    href="https://asana.com/uses/project-management"
+                    class="-white"
+                    >Project Management</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/product/goals" class="-white"
+                    >Goal Management</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a
+                    href="https://asana.com/uses/agile-management"
+                    class="-white"
+                    >Agile and Scrum</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a
+                    href="https://asana.com/uses/task-management"
+                    class="-white"
+                    >Task Management</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a
+                    href="https://asana.com/uses/increase-productivity"
+                    class="-white"
+                    >Increase Productivity</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a
+                    href="https://asana.com/uses/work-management"
+                    class="-white"
+                    >Work Management</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/uses" class="-white"
+                    >See All Uses</a
+                  >
+                </li>
+              </ul>
+              <ul class="siteFooter__list">
+                <li class="siteFooter__title">Team Solutions</li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/teams/engineering" class="-white"
+                    >Engineering</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/teams/designers" class="-white"
+                    >Designers</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/teams/sales" class="-white"
+                    >Sales</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/teams/hr" class="-white">HR</a>
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/teams/marketing" class="-white"
+                    >Marketing</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/teams/company-wide" class="-white"
+                    >Company-wide</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/teams" class="-white"
+                    >See All Teams</a
+                  >
+                </li>
+              </ul>
+              <ul class="siteFooter__list">
+                <li class="siteFooter__title">Resources</li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/guide" class="-white"
+                    >Asana Guide</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a
+                    href="https://forum.asana.com"
+                    class="-white"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >Forum</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/support" class="-white">Support</a>
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/apps" class="-white"
+                    >Integrations</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a
+                    href="https://developers.asana.com/docs/"
+                    class="-white"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >Developers &amp; API</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/partners" class="-white"
+                    >Partners</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a href="https://asana.com/community" class="-white"
+                    >Asana Community</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a
+                    href="https://certifiedpros.asana.com/"
+                    class="-white"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >Certified Pros</a
+                  >
+                </li>
+                <li class="siteFooter__item">
+                  <a
+                    href="https://events.asana.com/"
+                    class="-white"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >Events</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        <div class="siteFooter__secondary__wrapper">
+          <div class="container -wide">
+            <div class="siteFooter__row">
+              <div class="siteFooter__secondary__col-wrapper">
+                <div
+                  class="siteFooter__secondary__col siteFooter__secondary__col--terms"
+                >
+                  <a
+                    href="https://asana.com/terms"
+                    title="Terms &amp; Privacy"
+                    class="-white"
+                  >
+                    Terms &amp; Privacy
+                  </a>
+                </div>
+                <div
+                  class="siteFooter__secondary__col siteFooter__secondary__col--social"
+                >
+                  <a
+                    href="https://twitter.com/intent/follow?screen_name=asana"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <img
+                      src="https://luna1.co/twitter_icon-circle.svg"
+                      alt="twitter"
+                    />
+                  </a>
+                  <a
+                    href="https://www.linkedin.com/company/asana"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <img
+                      src="https://luna1.co/linkedin_icon-circle.svg"
+                      alt="linkedin"
+                    />
+                  </a>
+                  <a
+                    href="https://www.instagram.com/asana"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <img
+                      src="https://luna1.co/instagram_icon-circle.svg"
+                      alt="instagram"
+                    />
+                  </a>
+                  <a
+                    href="https://www.facebook.com/asana"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <img
+                      src="https://luna1.co/facebook_icon-circle.svg"
+                      alt="facebook"
+                    />
+                  </a>
+                  <a
+                    href="https://www.youtube.com/channel/UC2BoogM0AqwOJyoSp1S4ClQ"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <img
+                      src="https://luna1.co/youtube_icon-circle.svg"
+                      alt="youtube"
+                    />
+                  </a>
+                </div>
+                <div class="siteFooter__secondary__col">
+                  <a
+                    href="https://itunes.apple.com/us/app/asana-mobile/id489969512?mt=8"
+                    data-ois-button=""
+                    class="siteFooter-mobile-button"
+                  >
+                    <img
+                      src="https://luna1.co/Download_App_Store_Badge_US.svg"
+                      alt="Download App Button"
+                      title="Download App"
+                    />
+                  </a>
+                  <a
+                    href="https://play.google.com/store/apps/details?id=com.asana.app&amp;referrer=noredirect"
+                    data-android-button=""
+                    class="siteFooter-mobile-button"
+                  >
+                    <img
+                      src="https://luna1.co/Google_Play_EN.svg"
+                      alt="Download App Button"
+                      title="Download App"
+                    />
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
 
-    <footer class="siteFooter">
-      <div class="siteFooter__main__wrapper py-2 py-sm-5">
-        <div class="container -wide">
-          <div class="siteFooter__row">
-            <div class="siteFooter__logo mb-3 mb-md-0">
-              <a
-                href="https://asana.com/?noredirect"
-                class="siteFooter__logo-icon"
-              >
-                <span class="sr-only">Asana Logo</span>
-                <svg
-                  class="icon-svg icon-svg--dots icon--white"
-                  width="10"
-                  height="10"
-                  viewBox="0 0 32 32"
-                  preserveAspectRatio="xMinYMin"
-                >
-                  <path
-                    d="M23.1,8.1c0,3.8-3.1,6.9-7,6.9s-7-3.1-7-6.9c0-3.8,3.1-6.9,7-6.9S23.1,4.3,23.1,8.1C23.1,8.1,23.1,8.1,23.1,8.1z M7.1,16.7c-3.8,0-7,3.1-7,6.9s3.1,6.9,7,6.9s7-3.1,7-6.9S10.9,16.7,7.1,16.7C7.1,16.7,7.1,16.7,7.1,16.7z M25.1,16.7c-3.8,0-7,3.1-7,6.9s3.1,6.9,7,6.9s7-3.1,7-6.9S29,16.7,25.1,16.7C25.1,16.7,25.1,16.7,25.1,16.7z"
-                  />
-                </svg>
-              </a>
-            </div>
-            <ul class="siteFooter__list">
-              <li class="siteFooter__title">Asana</li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/?noredirect" class="-white">Home</a>
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/product" class="-white">Product</a>
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/pricing" class="-white">Pricing</a>
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/premium" class="-white">Premium</a>
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/business" class="-white">Business</a>
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/enterprise" class="-white"
-                  >Enterprise</a
-                >
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/customer-success" class="-white"
-                  >Customer Success</a
-                >
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/templates" class="-white"
-                  >Asana Templates</a
-                >
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/trust" class="-white"
-                  >Trust &amp; Security</a
-                >
-              </li>
-              <li class="siteFooter__item">
-                <a
-                  href="https://status.asana.com"
-                  class="-white"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  >Status</a
-                >
-              </li>
-            </ul>
-            <ul class="siteFooter__list">
-              <li class="siteFooter__title">About Us</li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/company" class="-white">Company</a>
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/leadership" class="-white"
-                  >Leadership</a
-                >
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/customers" class="-white"
-                  >Customers</a
-                >
-              </li>
-              <li class="siteFooter__item">
-                <a
-                  href="https://asana.com/diversity-and-inclusion"
-                  class="-white"
-                  >Diversity</a
-                >
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/jobs" class="-white">Careers</a>
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/press" class="-white">Press</a>
-              </li>
-              <li class="siteFooter__item">
-                <a
-                  href="https://wavelength.asana.com/"
-                  class="-white"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  >Wavelength</a
-                >
-              </li>
-              <li class="siteFooter__item">
-                <a
-                  href="https://blog.asana.com"
-                  class="-white"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  >Asana Blog</a
-                >
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/site-map" class="-white">Sitemap</a>
-              </li>
-            </ul>
-            <ul class="siteFooter__list">
-              <li class="siteFooter__title">Workflow Solutions</li>
-              <li class="siteFooter__item">
-                <a
-                  href="https://asana.com/uses/project-management"
-                  class="-white"
-                  >Project Management</a
-                >
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/product/goals" class="-white"
-                  >Goal Management</a
-                >
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/uses/agile-management" class="-white"
-                  >Agile and Scrum</a
-                >
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/uses/task-management" class="-white"
-                  >Task Management</a
-                >
-              </li>
-              <li class="siteFooter__item">
-                <a
-                  href="https://asana.com/uses/increase-productivity"
-                  class="-white"
-                  >Increase Productivity</a
-                >
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/uses/work-management" class="-white"
-                  >Work Management</a
-                >
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/uses" class="-white">See All Uses</a>
-              </li>
-            </ul>
-            <ul class="siteFooter__list">
-              <li class="siteFooter__title">Team Solutions</li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/teams/engineering" class="-white"
-                  >Engineering</a
-                >
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/teams/designers" class="-white"
-                  >Designers</a
-                >
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/teams/sales" class="-white">Sales</a>
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/teams/hr" class="-white">HR</a>
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/teams/marketing" class="-white"
-                  >Marketing</a
-                >
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/teams/company-wide" class="-white"
-                  >Company-wide</a
-                >
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/teams" class="-white"
-                  >See All Teams</a
-                >
-              </li>
-            </ul>
-            <ul class="siteFooter__list">
-              <li class="siteFooter__title">Resources</li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/guide" class="-white">Asana Guide</a>
-              </li>
-              <li class="siteFooter__item">
-                <a
-                  href="https://forum.asana.com"
-                  class="-white"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  >Forum</a
-                >
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/support" class="-white">Support</a>
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/apps" class="-white">Integrations</a>
-              </li>
-              <li class="siteFooter__item">
-                <a
-                  href="https://developers.asana.com/docs/"
-                  class="-white"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  >Developers &amp; API</a
-                >
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/partners" class="-white">Partners</a>
-              </li>
-              <li class="siteFooter__item">
-                <a href="https://asana.com/community" class="-white"
-                  >Asana Community</a
-                >
-              </li>
-              <li class="siteFooter__item">
-                <a
-                  href="https://certifiedpros.asana.com/"
-                  class="-white"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  >Certified Pros</a
-                >
-              </li>
-              <li class="siteFooter__item">
-                <a
-                  href="https://events.asana.com/"
-                  class="-white"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  >Events</a
-                >
-              </li>
-            </ul>
-          </div>
-        </div>
-      </div>
-      <div class="siteFooter__secondary__wrapper">
-        <div class="container -wide">
-          <div class="siteFooter__row">
-            <div class="siteFooter__secondary__col-wrapper">
-              <div
-                class="siteFooter__secondary__col siteFooter__secondary__col--terms"
-              >
-                <a
-                  href="https://asana.com/terms"
-                  title="Terms &amp; Privacy"
-                  class="-white"
-                >
-                  Terms &amp; Privacy
-                </a>
-              </div>
-              <div
-                class="siteFooter__secondary__col siteFooter__secondary__col--social"
-              >
-                <a
-                  href="https://twitter.com/intent/follow?screen_name=asana"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <img
-                    src="https://luna1.co/twitter_icon-circle.svg"
-                    alt="twitter"
-                  />
-                </a>
-                <a
-                  href="https://www.linkedin.com/company/asana"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <img
-                    src="https://luna1.co/linkedin_icon-circle.svg"
-                    alt="linkedin"
-                  />
-                </a>
-                <a
-                  href="https://www.instagram.com/asana"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <img
-                    src="https://luna1.co/instagram_icon-circle.svg"
-                    alt="instagram"
-                  />
-                </a>
-                <a
-                  href="https://www.facebook.com/asana"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <img
-                    src="https://luna1.co/facebook_icon-circle.svg"
-                    alt="facebook"
-                  />
-                </a>
-                <a
-                  href="https://www.youtube.com/channel/UC2BoogM0AqwOJyoSp1S4ClQ"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <img
-                    src="https://luna1.co/youtube_icon-circle.svg"
-                    alt="youtube"
-                  />
-                </a>
-              </div>
-              <div class="siteFooter__secondary__col">
-                <a
-                  href="https://itunes.apple.com/us/app/asana-mobile/id489969512?mt=8"
-                  data-ois-button=""
-                  class="siteFooter-mobile-button"
-                >
-                  <img
-                    src="https://luna1.co/Download_App_Store_Badge_US.svg"
-                    alt="Download App Button"
-                    title="Download App"
-                  />
-                </a>
-                <a
-                  href="https://play.google.com/store/apps/details?id=com.asana.app&amp;referrer=noredirect"
-                  data-android-button=""
-                  class="siteFooter-mobile-button"
-                >
-                  <img
-                    src="https://luna1.co/Google_Play_EN.svg"
-                    alt="Download App Button"
-                    title="Download App"
-                  />
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </footer>
     <style>
+      .flex-wrapper {
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
+      }
       #message {
         display: flex;
         align-items: center;
         justify-content: center;
         flex-direction: column;
+        flex: 1;
       }
       .siteFooter a {
         cursor: auto;

--- a/source/explorer/index.html
+++ b/source/explorer/index.html
@@ -8,20 +8,6 @@
       rel="icon"
       type="image/ico"
     />
-    <!-- Google Tag Manager -->
-    <!-- <script>
-      (function (w, d, s, l, i) {
-        w[l] = w[l] || [];
-        w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != "dataLayer" ? "&l=" + l : "";
-        j.async = true;
-        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
-        f.parentNode.insertBefore(j, f);
-      })(window, document, "script", "dataLayer", "GTM-58LRF8N");
-    </script> -->
-    <!-- End Google Tag Manager -->
     <script>
       const newSiteURL = "https://developers.asana.com/docs/api-explorer";
 

--- a/source/explorer/popup_receiver.html
+++ b/source/explorer/popup_receiver.html
@@ -1,17 +1,18 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE html PUBLIC "-//IETF//DTD HTML//EN">
 <html>
-<head>
-    <title>Asana Oauth Example: Browser Popup Receiver</title>
-    <script src="asana-explorer.js"></script>
-</head>
-<body>
-<script>
-    /**
-     * The popup that asks for user authorization will redirect back to this
-     * page. The below code does the handshake with the parent window and
-     * completes the authorization, automatically closing the window.
-     */
-    AsanaExplorer.Receiver.run();
-</script>
-</body>
+  <head>
+    <title>Redirecting...</title>
+    <meta
+      http-equiv="refresh"
+      content="0;url=https://developers.asana.com/docs/api-explorer"
+    />
+  </head>
+  <body>
+    <p>
+      If you are not redirected automatically, follow this
+      <a href="https://developers.asana.com/docs/api-explorer"
+        >link for the current API explorer</a
+      >.
+    </p>
+  </body>
 </html>

--- a/source/explorer/popup_receiver.html
+++ b/source/explorer/popup_receiver.html
@@ -10,9 +10,8 @@
   <body>
     <p>
       If you are not redirected automatically, follow this
-      <a href="https://developers.asana.com/docs/api-explorer"
-        >link for the current API explorer</a
-      >.
+      <a href="https://developers.asana.com/docs/api-explorer">link</a> for the
+      current API explorer.
     </p>
   </body>
 </html>


### PR DESCRIPTION
- Remove React root (where legacy explorer content loads)
- Remove Google Tag Manager
- Remove OAuth-related scripts in `popup_receiver.html`
- Force an automatic redirect to the current API explorer after 8 seconds
- Update CSS to push the footer to the bottom of the page
- Format HTML

![redirect](https://github.com/user-attachments/assets/c2e4fa0e-1b73-4fb3-9ce2-97a6f165cdee)
